### PR TITLE
Add msys2_mingw_dependencies to gemspec

### DIFF
--- a/opencv-ruby.gemspec
+++ b/opencv-ruby.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
                          "ext/rice/*.hpp",
                          "test/*.rb"])
 
+	spec.metadata['msys2_mingw_dependencies'] = 'opencv qt6-base cmake libffi'
   # 6.0 breaks RubyMine
 	spec.add_development_dependency('minitest', '~>5.0')
 	spec.add_development_dependency('rake')


### PR DESCRIPTION
It automatically installs the necessary packages when using the RubyInstaller.

This is described in https://github.com/oneclick/rubyinstaller2/wiki/For-gem-developers#-msys2-library-dependency