### PR TITLE
Fix macOS OpenCV 4.13 + Ruby 4 build/runtime issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,38 @@ Ruby bindings for OpenCV4 based on its C++ API. Almost all of OpenCV's API is ex
 
 See [installation](https://cfis.github.io/opencv-ruby/installation/)
 
+## Build from Source on macOS
+
+The following setup was used to successfully build `opencv-ruby` on Apple Silicon macOS with Homebrew OpenCV 4.13 and Ruby 4.0.x (RVM):
+
+* Xcode Command Line Tools (`xcode-select --install`)
+* CMake 3.26+ (`brew install cmake`)
+* Ninja (`brew install ninja`)
+* OpenCV (`brew install opencv`)
+* pkg-config (`brew install pkg-config`)
+
+Recommended install command:
+
+```sh
+RUBY_EXE="$(rvm which ruby)"
+RUBY_LIB="$(ruby -rrbconfig -e 'puts File.join(RbConfig::CONFIG[\"libdir\"], RbConfig::CONFIG[\"LIBRUBY_SO\"])')"
+RUBY_HDR="$(ruby -rrbconfig -e 'puts RbConfig::CONFIG[\"rubyhdrdir\"]')"
+RUBY_ARCH_HDR="$(ruby -rrbconfig -e 'puts RbConfig::CONFIG[\"rubyarchhdrdir\"]')"
+
+gem install opencv-ruby -- --preset macos-release \
+  -DCMAKE_NO_SYSTEM_FROM_IMPORTED=ON \
+  -DRuby_EXECUTABLE="$RUBY_EXE" \
+  -DRuby_LIBRARY="$RUBY_LIB" \
+  -DRuby_INCLUDE_DIR="$RUBY_HDR" \
+  -DRuby_CONFIG_INCLUDE_DIR="$RUBY_ARCH_HDR"
+```
+
+Notes:
+
+* `-DCMAKE_NO_SYSTEM_FROM_IMPORTED=ON` avoids header-order conflicts when legacy headers are present in `/usr/local/include/opencv2`.
+* Passing explicit `Ruby_*` paths helps when RVM has multiple Rubies installed and CMake picks the wrong one.
+* The final link step can take several minutes and may show high CPU in `ld`; this is expected.
+
 ## Getting Started 
 
 See [getting started](https://cfis.github.io/opencv-ruby/getting-started/)

--- a/README.md
+++ b/README.md
@@ -14,38 +14,6 @@ Ruby bindings for OpenCV4 based on its C++ API. Almost all of OpenCV's API is ex
 
 See [installation](https://cfis.github.io/opencv-ruby/installation/)
 
-## Build from Source on macOS
-
-The following setup was used to successfully build `opencv-ruby` on Apple Silicon macOS with Homebrew OpenCV 4.13 and Ruby 4.0.x (RVM):
-
-* Xcode Command Line Tools (`xcode-select --install`)
-* CMake 3.26+ (`brew install cmake`)
-* Ninja (`brew install ninja`)
-* OpenCV (`brew install opencv`)
-* pkg-config (`brew install pkg-config`)
-
-Recommended install command:
-
-```sh
-RUBY_EXE="$(rvm which ruby)"
-RUBY_LIB="$(ruby -rrbconfig -e 'puts File.join(RbConfig::CONFIG[\"libdir\"], RbConfig::CONFIG[\"LIBRUBY_SO\"])')"
-RUBY_HDR="$(ruby -rrbconfig -e 'puts RbConfig::CONFIG[\"rubyhdrdir\"]')"
-RUBY_ARCH_HDR="$(ruby -rrbconfig -e 'puts RbConfig::CONFIG[\"rubyarchhdrdir\"]')"
-
-gem install opencv-ruby -- --preset macos-release \
-  -DCMAKE_NO_SYSTEM_FROM_IMPORTED=ON \
-  -DRuby_EXECUTABLE="$RUBY_EXE" \
-  -DRuby_LIBRARY="$RUBY_LIB" \
-  -DRuby_INCLUDE_DIR="$RUBY_HDR" \
-  -DRuby_CONFIG_INCLUDE_DIR="$RUBY_ARCH_HDR"
-```
-
-Notes:
-
-* `-DCMAKE_NO_SYSTEM_FROM_IMPORTED=ON` avoids header-order conflicts when legacy headers are present in `/usr/local/include/opencv2`.
-* Passing explicit `Ruby_*` paths helps when RVM has multiple Rubies installed and CMake picks the wrong one.
-* The final link step can take several minutes and may show high CPU in `ld`; this is expected.
-
 ## Getting Started 
 
 See [getting started](https://cfis.github.io/opencv-ruby/getting-started/)

--- a/ext/opencv2/core/bindings_utils-rb.cpp
+++ b/ext/opencv2/core/bindings_utils-rb.cpp
@@ -13,13 +13,22 @@ Rice::Class rb_cCvUtilsNestedOriginalClassNameParams;
 
 static int set_log_level_int(int level)
 {
+#if CV_VERSION_MAJOR > 4 || (CV_VERSION_MAJOR == 4 && CV_VERSION_MINOR >= 13)
   return static_cast<int>(cv::utils::logging::setLogLevel(
     static_cast<cv::utils::logging::LogLevel>(level)));
+#else
+  return static_cast<int>(cv::setLogLevel(
+    static_cast<cv::utils::logging::LogLevel>(level)));
+#endif
 }
 
 static int get_log_level_int()
 {
+#if CV_VERSION_MAJOR > 4 || (CV_VERSION_MAJOR == 4 && CV_VERSION_MINOR >= 13)
   return static_cast<int>(cv::utils::logging::getLogLevel());
+#else
+  return static_cast<int>(cv::getLogLevel());
+#endif
 }
 
 void Init_BindingsUtils()

--- a/ext/opencv2/core/bindings_utils-rb.cpp
+++ b/ext/opencv2/core/bindings_utils-rb.cpp
@@ -11,6 +11,17 @@ Rice::Class rb_cCvUtilsFunctionParams;
 Rice::Class rb_cCvUtilsNestedOriginalClassName;
 Rice::Class rb_cCvUtilsNestedOriginalClassNameParams;
 
+static int set_log_level_int(int level)
+{
+  return static_cast<int>(cv::utils::logging::setLogLevel(
+    static_cast<cv::utils::logging::LogLevel>(level)));
+}
+
+static int get_log_level_int()
+{
+  return static_cast<int>(cv::utils::logging::getLogLevel());
+}
+
 void Init_BindingsUtils()
 {
   Module rb_mCv = define_module("Cv");
@@ -159,8 +170,8 @@ void Init_BindingsUtils()
   
   rb_mCvUtilsFs.define_module_function("get_cache_directory_for_downloads", &cv::utils::fs::getCacheDirectoryForDownloads);
   
-  rb_mCv.define_module_function("set_log_level", &cv::setLogLevel,
+  rb_mCv.define_module_function("set_log_level", &set_log_level_int,
     Arg("level"));
   
-  rb_mCv.define_module_function("get_log_level", &cv::getLogLevel);
+  rb_mCv.define_module_function("get_log_level", &get_log_level_int);
 }

--- a/ext/opencv2/core/mat-rb.cpp
+++ b/ext/opencv2/core/mat-rb.cpp
@@ -593,7 +593,7 @@ void Init_Mat()
       Arg("i") = static_cast<int>(-1)).
     define_method("submatrix?", &cv::_InputArray::isSubmatrix,
       Arg("i") = static_cast<int>(-1)).
-    define_method("empty?", &cv::_InputArray::empty).
+    define_method("empty?", static_cast<bool(cv::_InputArray::*)() const>(&cv::_InputArray::empty)).
     define_method<void(cv::_InputArray::*)(const cv::_OutputArray&) const>("copy_to", &cv::_InputArray::copyTo,
       Arg("arr")).
     define_method<void(cv::_InputArray::*)(const cv::_OutputArray&, const cv::_InputArray&) const>("copy_to", &cv::_InputArray::copyTo,

--- a/ext/opencv2/imgproc-rb.cpp
+++ b/ext/opencv2/imgproc-rb.cpp
@@ -561,11 +561,11 @@ void Init_Imgproc()
     define_constructor(Constructor<cv::Subdiv2D>()).
     define_constructor(Constructor<cv::Subdiv2D, cv::Rect>(),
       Arg("rect")).
-    define_method("init_delaunay", &cv::Subdiv2D::initDelaunay,
+    define_method("init_delaunay", static_cast<void(cv::Subdiv2D::*)(cv::Rect)>(&cv::Subdiv2D::initDelaunay),
       Arg("rect")).
-    define_method<int(cv::Subdiv2D::*)(cv::Point2f)>("insert", &cv::Subdiv2D::insert,
+    define_method("insert", static_cast<int(cv::Subdiv2D::*)(cv::Point2f)>(&cv::Subdiv2D::insert),
       Arg("pt")).
-    define_method<void(cv::Subdiv2D::*)(const std::vector<cv::Point_<float>>&)>("insert", &cv::Subdiv2D::insert,
+    define_method("insert", static_cast<void(cv::Subdiv2D::*)(const std::vector<cv::Point2f>&)>(&cv::Subdiv2D::insert),
       Arg("ptvec")).
     define_method("locate", &cv::Subdiv2D::locate,
       Arg("pt"), Arg("edge"), Arg("vertex")).

--- a/ext/opencv2/video/background_segm-rb.cpp
+++ b/ext/opencv2/video/background_segm-rb.cpp
@@ -13,7 +13,7 @@ void Init_BackgroundSegm()
   Module rb_mCv = define_module("Cv");
   
   rb_cCvBackgroundSubtractor = define_class_under<cv::BackgroundSubtractor, cv::Algorithm>(rb_mCv, "BackgroundSubtractor").
-    define_method("apply", &cv::BackgroundSubtractor::apply,
+    define_method<void(cv::BackgroundSubtractor::*)(cv::InputArray, cv::OutputArray, double)>("apply", &cv::BackgroundSubtractor::apply,
       Arg("image"), Arg("fgmask"), Arg("learning_rate") = static_cast<double>(-1)).
     define_method("get_background_image", &cv::BackgroundSubtractor::getBackgroundImage,
       Arg("background_image"));
@@ -55,7 +55,7 @@ void Init_BackgroundSegm()
     define_method("get_shadow_threshold", &cv::BackgroundSubtractorMOG2::getShadowThreshold).
     define_method("set_shadow_threshold", &cv::BackgroundSubtractorMOG2::setShadowThreshold,
       Arg("threshold")).
-    define_method("apply", &cv::BackgroundSubtractorMOG2::apply,
+    define_method<void(cv::BackgroundSubtractorMOG2::*)(cv::InputArray, cv::OutputArray, double)>("apply", &cv::BackgroundSubtractorMOG2::apply,
       Arg("image"), Arg("fgmask"), Arg("learning_rate") = static_cast<double>(-1));
   
   rb_mCv.define_module_function("create_background_subtractor_mog2", &cv::createBackgroundSubtractorMOG2,


### PR DESCRIPTION
Hi,

I hit a reproducible install failure on macOS (Apple Silicon) when building `opencv-ruby` against Homebrew OpenCV 4.13 and Ruby 4.0.1 (RVM), and put together a focused fix.

## What failed

- Compile break from API drift in OpenCV 4.13 (`cv::setLogLevel` / `cv::getLogLevel` no longer resolve in `cv::`).
- Overload resolution failures in bindings for:
  - `_InputArray::empty`
  - `BackgroundSubtractor::apply`
  - `Subdiv2D::initDelaunay` and `Subdiv2D::insert`
- Runtime load failure after build:
  - Rice error: `cv::utils::logging::LogLevel` type not registered.

## What this PR changes

- Adds explicit overload casts where needed to disambiguate method bindings.
- Uses `int` wrappers for log-level methods so Rice does not require enum registration.
- Adds OpenCV version guards for log-level calls to keep compatibility with pre-4.13 namespace layout.

## Validation

- `gem install opencv-ruby -- --preset macos-release ...` succeeds on macOS arm64.
- `require 'opencv_ruby'` succeeds.
- `Cv.get_log_level` and `Cv.set_log_level` both work.

This patch was generated with Codex and then manually validated against the failing install/build path above.

Thanks for taking a look.
